### PR TITLE
Fixes vinta/awesomepython link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A curated list of awesome Monorepo tools, software and
 architectures. Inspired
-by [https://github.com/vinta/awesome-python](awesome-python).
+by [https://github.com/vinta/awesome-python](https://github.com/vinta/awesome-python).
 
 ## Build systems & dependency management tools
 


### PR DESCRIPTION
The link doesn't work in the GitHub UI currently. It takes you to https://github.com/korfuri/awesome-monorepo/blob/master/awesome-python

This corrects the link issue