### PR TITLE
Add Entria's Full Stack Monorepo to Notable public monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Inspired by [https://github.com/vinta/awesome-python](https://github.com/vinta/a
 * [Stellar's Go monorepo](https://github.com/stellar/go)
 * [Habitat's monorepo](https://github.com/habitat-sh/habitat)
 * [startup-os monorepo: working examples for Google's Open Source tools (bazel, etc) in a monorepo](https://github.com/google/startup-os)
-* [Entria's Full Stack Monorepo](https://github.com/entria/entria-fullstack)
+* [Entria's Full Stack Playground Monorepo](https://github.com/entria/entria-fullstack)
 
 ## Migration tools
 


### PR DESCRIPTION
Since we've been working with monorepo, we decided to open source a playground repo with lots of approaches and best practices. This is a list of good stuff we've learned with monorepo and are sharing at [Entria Full Stack](https://github.com/entria/entria-fullstack):
- share babel config
- share jest config
- tramspile from ts
- use both flow and ts
- release scripts
- build only modified packages

what else?

There's also a list of issues we are still working: https://github.com/entria/entria-fullstack/issues