### PR TITLE
Add a link to `spago`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Inspired by [https://github.com/vinta/awesome-python](vinta/awesome-python).
 * [Bolt Pkg](https://github.com/boltpkg/bolt) is a super-powered JavaScript project management.
 * [GitLab CI](https://gitlab.com/gitlab-org/gitlab-ce/issues/19232) 11.4 supports running steps based on path changes.
 * [Symplify/MonorepoBuilder](https://github.com/Symplify/MonorepoBuilder) is a PHP monorepo management tool.
+* [Spago](https://github.com/spacchetti/spago) is a PureScript package manager and build tool powered by Dhall and package-sets.
+
 
 ## Repository management tools
 


### PR DESCRIPTION
`spago` is a package manager for PureScript.
It supports creating monorepos:
https://github.com/spacchetti/spago#separate-devdependencies-or-test-dependencies.

cc @f-f