### PR TITLE
Adding `codeowners-generator` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [GitHub's CODEOWNERS](https://help.github.com/articles/about-codeowners/) can restrict who can approve a pull request that affects a given part of a monorepo.
 * [Chromium's OWNERS file](https://chromium.googlesource.com/chromium/src/+/master/docs/code_reviews.md#OWNERS-files) inspired GitHub's CODEOWNERS.
 * [Write Guard](https://github.com/geritol/write-guard) uses GitHub actions to enforce file-level write access to a monorepo.
+* [CODEOWNERS generator](https://github.com/gagoar/codeowners-generator) (nested) CODEOWNERS solution for mono repos
 
 ## Notable public monorepos
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [GitHub's CODEOWNERS](https://help.github.com/articles/about-codeowners/) can restrict who can approve a pull request that affects a given part of a monorepo.
 * [Chromium's OWNERS file](https://chromium.googlesource.com/chromium/src/+/master/docs/code_reviews.md#OWNERS-files) inspired GitHub's CODEOWNERS.
 * [Write Guard](https://github.com/geritol/write-guard) uses GitHub actions to enforce file-level write access to a monorepo.
-* [CODEOWNERS generator](https://github.com/gagoar/codeowners-generator) (nested) CODEOWNERS solution for mono repos
+* [CODEOWNERS generator](https://github.com/gagoar/codeowners-generator) generates a CODEOWNERS file for your monorepo from files in subfolders.
 
 ## Notable public monorepos
 


### PR DESCRIPTION
Hi! thanks for your repo!

We have been using [codeowners-generator](https://github.com/gagoar/codeowners-generator) for handling ownership of different teams in the same repo, and I thought it will be useful to others as well. 



