### PR TITLE
Add mgt to repository management tools and git addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 ## Repository management tools
 
 * [Builder](https://github.com/FormidableLabs/builder) is a tool that makes it possible to ship the same scripts across projects in a Node.js monorepo. For example, share build and testing scripts across projects.
-* [mgt](https://github.com/nikita-skobov/monorepo-git-tools) is a tool that enables easy bidirectional sync between multiple repositories via files that define how to remap a repository
 * [FBShipIt](https://github.com/facebook/fbshipit) is a library written in Hack for copying commits from one repository to another.
 * [adeira/shipit](https://github.com/adeira/shipit) is a simplified JavaScript port of FBShipIt.
 * [Lank](https://github.com/FormidableLabs/lank) is a tool that links packages together in a Node.js monorepo using automatic configuration of `NODE_PATH` instead of symlinks. Lank also allows you to run the same commands across all (or subsets of all) packages.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 ## Repository management tools
 
 * [Builder](https://github.com/FormidableLabs/builder) is a tool that makes it possible to ship the same scripts across projects in a Node.js monorepo. For example, share build and testing scripts across projects.
+* [mgt](https://github.com/nikita-skobov/monorepo-git-tools) is a tool that enables easy bidirectional sync between multiple repositories via files that define how to remap a repository
 * [FBShipIt](https://github.com/facebook/fbshipit) is a library written in Hack for copying commits from one repository to another.
 * [adeira/shipit](https://github.com/adeira/shipit) is a simplified JavaScript port of FBShipIt.
 * [Lank](https://github.com/FormidableLabs/lank) is a tool that links packages together in a Node.js monorepo using automatic configuration of `NODE_PATH` instead of symlinks. Lank also allows you to run the same commands across all (or subsets of all) packages.
@@ -85,6 +86,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [splitsh-lite](https://github.com/splitsh/lite) is a very fast git subtree alternative to splits subtrees from your project into subprojects.
 * [josh](https://github.com/esrlabs/josh) is a git server proxy enabling on-the-fly virtualization of repositories.
 * [go-diff](https://github.com/dstreamcloud/go-diff) is a handy tool analyzes which packages needed to be rebuilt due to changes.
+* [mgt](https://github.com/nikita-skobov/monorepo-git-tools) is a tool that enables easy bidirectional sync between multiple repositories via files that define how to remap a repository
 
 #### Scaling info
 


### PR DESCRIPTION
Hi, I've been working on `mgt` (monorepo git tools) for the better part of a year now, and I think it's mature enough to display. I think it would make a good fit on this awesome list.

I use it every day to manage dozens of repositories both public and private
