### PR TITLE
add layer-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [Symplify/MonorepoBuilder](https://github.com/Symplify/MonorepoBuilder) is a PHP monorepo management tool.
 * [Tainted](https://github.com/kynrai/tainted) is a tool to determine which Go packages need to be rebuilt in a monorepo.
 * [Yarn](https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/) is a JavaScript dependency management tool that supports monorepos through workspaces.
+* [Layer-pack](https://github.com/layer-pack/layer-pack) is a Webpack plugin allowing monorepo structures via inheritable npm packages/code layers & es6 glob imports
 
 ## Repository management tools
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [Symplify/MonorepoBuilder](https://github.com/Symplify/MonorepoBuilder) is a PHP monorepo management tool.
 * [Tainted](https://github.com/kynrai/tainted) is a tool to determine which Go packages need to be rebuilt in a monorepo.
 * [Yarn](https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/) is a JavaScript dependency management tool that supports monorepos through workspaces.
-* [Layer-pack](https://github.com/layer-pack/layer-pack) is a Webpack plugin allowing monorepo structures via inheritable npm packages/code layers & es6 glob imports
+* [Layer-pack](https://github.com/layer-pack/layer-pack) is a Webpack plugin allowing monorepo structures via inheritable npm packages/code layers & es6 glob imports.
 
 ## Repository management tools
 


### PR DESCRIPTION
Hi ! 
While it's not very well known; it allows to efficiently split large projects on a mono-repo structure; while keeping hot reloads, source maps, etc.
It doesn't need Yarn or presume any framework except the use of JS/Babel

Also deal with es6 glob imports, shared webpack conf, etc.. so it's awesome for me :)