### PR TITLE
Add "Versio" to dependency tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [Spago](https://github.com/spacchetti/spago) is a PureScript package manager and build tool powered by Dhall and package-sets.
 * [Symplify/MonorepoBuilder](https://github.com/Symplify/MonorepoBuilder) is a PHP monorepo management tool.
 * [Tainted](https://github.com/kynrai/tainted) is a tool to determine which Go packages need to be rebuilt in a monorepo.
+* [Versio](https://github.com/chaaz/versio) updates all version numbers in monorepo projects based on [conventional commits](https://www.conventionalcommits.org/), and can generate changelogs and tags.
 * [Yarn](https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/) is a JavaScript dependency management tool that supports monorepos through workspaces.
 * [Layer-pack](https://github.com/layer-pack/layer-pack) is a Webpack plugin allowing monorepo structures via inheritable npm packages/code layers & es6 glob imports.
 


### PR DESCRIPTION
I am the author of Versio, which is (IMHO) a neat little tool that keeps track of all your version numbers, so you don't have to. In a monorepo specifically, it can track which commits affect which projects in the monorepo (even if you've squashed-merged them), and can handle dependencies among the different projects.