### PR TITLE
docs: add front end monorepo boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [Berty's monorepo - React-native mobile App + Golang backend + Gomobile bridge + iOS & Android native drivers + Protobuf](https://github.com/berty/berty/)
 * [NixOS's monorepo of packages and modules can be used to incrementally build and deploy Linux machines](https://github.com/NixOS/nixpkgs/)
 * [Celo's monorepo (includes blockchain, misc tooling, libraries, ops stuff like terraform modules, docs, etc)](https://github.com/celo-org/celo-monorepo)
+* [Monorepo Boilerplate - React + Typescript + Lerna + create-react-app (without react-app-rewired) + storybook + design tokens + styled-components + semantic release](https://github.com/emunhoz/monorepo-boilerplate)
 
 ## Migration tools
 


### PR DESCRIPTION
Hello.

This PR adds a link to a monorepo start boilerplate to build large scale front end applications.

Stack:

- React
- Typescript
- Create react app
- Storybook
- Semantic release

Some useful links:
- Storybook: https://monorepo-boilerplate-storybook.vercel.app/?path=/docs/
- Design tokens doc: https://monorepo-boilerplate-storybook.vercel.app/?path=/docs/design-system-colors--page
- CRA demo: https://monorepo-boilerplate-cra.vercel.app/