### PR TITLE
docs: add front end monorepo boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [Berty's monorepo - React-native mobile App + Golang backend + Gomobile bridge + iOS & Android native drivers + Protobuf](https://github.com/berty/berty/)
 * [NixOS's monorepo of packages and modules can be used to incrementally build and deploy Linux machines](https://github.com/NixOS/nixpkgs/)
 * [Celo's monorepo (includes blockchain, misc tooling, libraries, ops stuff like terraform modules, docs, etc)](https://github.com/celo-org/celo-monorepo)
+* [Monorepo starter (inculdes storybook,vue,jsdoc etc)](https://github.com/BryanAdamss/monorepo-starter)
 
 ## Migration tools
 


### PR DESCRIPTION
Hello.

This PR adds a link to a monorepo start boilerplate to build large scale front end applications.