### PR TITLE
Add makefile-for-monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Inspired by [vinta/awesome-python](https://github.com/vinta/awesome-python).
 * [Garment](https://github.com/Farfetch/garment) is Farfetch's monorepo build system with centralized and customizable task management.
 * [GitLab CI](https://gitlab.com/gitlab-org/gitlab-ce/issues/19232) 11.4 supports running steps based on path changes.
 * [Lerna](https://lerna.js.org/) is a tool for managing JavaScript projects with multiple packages, built on Yarn.
+* [makefile-for-monorepos](https://github.com/enspirit/makefile-for-monorepos) is a Makefile solution for Dockerfile based monorepos.
 * [MBT](https://github.com/mbtproject/mbt) is a build tool with differential build support.
 * [Nix](https://github.com/NixOS/nix) is a package and distribution build tool with remote caching, predominately used by NixOS.
 * [Nx](https://nx.dev/) is a build system for TypeScript monorepos and a set of monorepo management tools.


### PR DESCRIPTION
makefile-for-monorepo is a GNU Make solution for Dockerfile-based monorepos. It's extensible and fairly powerful.