### PR TITLE
fix: Update Google monorepo link to resolve broken URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ English | [简体中文](./README-zh-CN.md)
 
 ## Good reads
 
-* [Why Google Stores Billions of Lines of Code in a Single Repository](https://research.google.com/pubs/pub45424.html)
+* [Why Google Stores Billions of Lines of Code in a Single Repository](https://research.google.com/pubs/pub45424.html?)
 * [Advantages and Disadvantages of a Monolithic Repository: A case study at Google](https://people.engr.ncsu.edu/ermurph3/papers/seip18.pdf)
 * [Why you should use a single repository for all your company’s projects](https://www.drmaciver.com/2016/10/why-you-should-use-a-single-repository-for-all-your-companys-projects/)
 * [Advantages of monorepos](https://danluu.com/monorepo/)


### PR DESCRIPTION
This commit fixes a broken link in the “Good Reads” section of the documentation. The link to the Google article, “Why Google Stores Billions of Lines of Code in a Single Repository”, was previously not working due to a missing ? at the end of the URL.

**The corrected link now points to the intended page:**
[https://research.google.com/pubs/pub45424.html?](https://research.google.com/pubs/pub45424.html?)

**Changes Made**
- Added a ? at the end of the URL for the link “Why Google Stores Billions of Lines of Code in a Single Repository” to resolve the broken link issue.

**Impact**
This change ensures that readers can access the correct Google Research page, improving the usability and accuracy of the documentation.